### PR TITLE
Builtins, Variable declarations and underscores in identifiers

### DIFF
--- a/VM/Language/Compiler/Binding/BoundNode.ts
+++ b/VM/Language/Compiler/Binding/BoundNode.ts
@@ -238,6 +238,7 @@ export class BoundUnaryOperator
         new BoundUnaryOperator(SyntaxType.Bang, BoundUnaryOperatorKind.LogicalNegation, PredefinedValueTypes.Boolean),
         new BoundUnaryOperator(SyntaxType.Plus, BoundUnaryOperatorKind.Identity, PredefinedValueTypes.Integer),
         new BoundUnaryOperator(SyntaxType.Minus, BoundUnaryOperatorKind.Negation, PredefinedValueTypes.Integer),
+        new BoundUnaryOperator(SyntaxType.Minus, BoundUnaryOperatorKind.Negation, PredefinedValueTypes.Float),
     ];
 
     public static Bind(syntaxKind : SyntaxType, operandType: Type) : BoundUnaryOperator | null 
@@ -368,7 +369,7 @@ export class ParameterDeclaration
 
 export class BoundVariableDeclaration extends BoundStatement
 {
-    constructor(variable : VariableSymbol, initialiser : BoundExpression)
+    constructor(variable : VariableSymbol, initialiser : BoundExpression|null)
     {        
         super();
         this.variable = variable;
@@ -377,7 +378,7 @@ export class BoundVariableDeclaration extends BoundStatement
 
     public get kind() { return BoundNodeKind.VariableDeclaration };
     public readonly variable : VariableSymbol; 
-    public readonly initialiser : BoundExpression;
+    public readonly initialiser : BoundExpression|null;
 }
 
 export class BoundIfStatement extends BoundStatement

--- a/VM/Language/Compiler/Binding/BoundNodePrinter.ts
+++ b/VM/Language/Compiler/Binding/BoundNodePrinter.ts
@@ -136,9 +136,12 @@ export class BoundNodePrinter
         this.WriteSpace(writer);
         this.WriteIdentifier(writer, node.variable.name);
         this.WriteSpace(writer);
-        this.WritePunctuation(writer, SyntaxType.Equals);
-        this.WriteSpace(writer);
-        this.WriteTo(node.initialiser, writer);
+        if(node.initialiser)
+        {
+            this.WritePunctuation(writer, SyntaxType.Equals);
+            this.WriteSpace(writer);        
+            this.WriteTo(node.initialiser, writer);
+        }
         this.WriteLine(writer);
     }
 

--- a/VM/Language/Compiler/Lowering/Lowerer.ts
+++ b/VM/Language/Compiler/Lowering/Lowerer.ts
@@ -222,4 +222,22 @@ export default class Lowerer extends BoundTreeTransformBase
 
         return getExpression;
     }
+
+    transformVariableDeclarationStatement(declaration: Nodes.BoundVariableDeclaration): Nodes.BoundStatement 
+    {
+        if(declaration.initialiser)
+        {
+            const initialiser = this.transformExpression(declaration.initialiser);
+
+            const newDeclaration = new Nodes.BoundVariableDeclaration(declaration.variable, null);
+            const variable = new Identifier(declaration.variable.name, declaration.variable.type, declaration.variable);
+            const variableExpression = new Nodes.BoundVariableExpression(variable);
+            const assignment = new Nodes.BoundAssignmentStatement(variableExpression, initialiser);
+
+            this._currentVariableDeclarationList.push(newDeclaration);
+            return assignment;        
+        }        
+
+        return declaration;
+    }
 }

--- a/VM/Language/Compiler/Syntax/Lexer.ts
+++ b/VM/Language/Compiler/Syntax/Lexer.ts
@@ -128,7 +128,7 @@ export default class Lexer implements ILexer
             case '.' :
                 return SyntaxType.Dot;                                                                
             default:
-                if(this.isLetter(c))
+                if(this.isLetter(c) || c == '_')
                     return this.identifierOrKeyword();
                 
                 this._diagnostics.reportUnexpectedCharacter(c.toString(), this.start);
@@ -278,7 +278,7 @@ export default class Lexer implements ILexer
     }
 
     identifier(): SyntaxType {
-        while(this.isLetter(this.char) || this.isDigit(this.char))
+        while(this.isLetter(this.char) || this.isDigit(this.char) || this.char == '_')
             this.advance();
 
         return SyntaxType.Identifier;

--- a/VM/Language/LoweredBoundTreeInterpreter/Interpreter.ts
+++ b/VM/Language/LoweredBoundTreeInterpreter/Interpreter.ts
@@ -4,6 +4,7 @@ import { ValueType } from "../Types/ValueType";
 import { PredefinedValueTypes } from "../Types/PredefinedValueTypes";
 import { Identifier } from "../Scope/DefinitionScope";
 import Stack from "../../misc/Stack";
+import TypeQuery from "../Types/TypeInspection";
 
 export default class Evaluator
 {
@@ -26,7 +27,13 @@ export default class Evaluator
         let decs : any[] = [];
 
         for (const variable of root.variables) {            
-            let value = this.EvaluateExpression(variable.initialiser);
+            let value : any;
+            
+            if(variable.initialiser)
+                value = this.EvaluateExpression(variable.initialiser);
+            else
+                throw new Error("Fix this. initialiser is null");
+
             this._globals[variable.variable.name] = value;
         }
 
@@ -99,9 +106,25 @@ export default class Evaluator
 
     private EvaluateVariableDeclaration(node : Nodes.BoundVariableDeclaration) : void
     {
-        var value = this.EvaluateExpression(node.initialiser);
+        var value = this.getDefaultValueForType(node.variable.type.type); // this.EvaluateExpression(node.initialiser!);
         this._lastValue = value;
         this.Assign(node.variable, value);
+    }
+
+    private getDefaultValueForType(type : ValueType) : any
+    {
+        switch(type)
+        {
+            case ValueType.Boolean:
+            case ValueType.Float:
+            case ValueType.Int:
+            case ValueType.Pointer:
+                return 0;
+            case ValueType.String:
+                return "";
+            default:
+                throw new Error("Default Type Not Implemented");
+        }
     }
 
     private Assign(variable: Nodes.VariableSymbol, value : Value) : void

--- a/VM/VirtualMachine/CPU/CPU.ts
+++ b/VM/VirtualMachine/CPU/CPU.ts
@@ -5,6 +5,7 @@ import Instruction from "./Instruction/Instruction";
 import InstructionCoder from "./Instruction/InstructionCoder";
 import { MapOpCodeToExecutor } from "./Instruction/InstructionSet";
 import { InstructionExecutor } from "./Instruction/Instructions/InstructionExecutor";
+import BuiltinFunctions, { BuiltinFunction } from "../../Language/Compiler/BuiltinFunctions";
 
 export default class CPU
 {        
@@ -12,13 +13,15 @@ export default class CPU
     private registers : RegisterBank;
     private flags : Flags;
     private instructionDecoder : InstructionCoder;
+    public readonly builtins : BuiltinFunctions;
 
-    constructor(ram : Memory, registers : RegisterBank, flags : Flags, instructionDecoder : InstructionCoder)
+    constructor(ram : Memory, registers : RegisterBank, flags : Flags, instructionDecoder : InstructionCoder, builtins? : BuiltinFunctions)
     {        
         this.ram = ram;
         this.registers = registers;
         this.flags = flags;
         this.instructionDecoder = instructionDecoder;
+        this.builtins = builtins || new BuiltinFunctions();
     }
 
     public step(): Instruction {

--- a/VM/tests/Compiler/CodeGenerator/CodeGenerator.tests.ts
+++ b/VM/tests/Compiler/CodeGenerator/CodeGenerator.tests.ts
@@ -138,8 +138,13 @@ __entrypoint:
 main:
     PUSH R6
     MOV R6 SP
+    MOV R1 0
+    PUSH R1
     MVI R1 0
     PUSH R1
+    MOV R1, R6-4
+    POP R2
+    MOV [R1] R2
     MVI R1 5
     PUSH R1
     MOV R1, R6-4
@@ -192,16 +197,41 @@ __entrypoint:
 main:
     PUSH R6
     MOV R6 SP
+    MOV R1 0
+    PUSHf R1
+    MOV R1 0
+    PUSH R1
+    MOV R1 0
+    PUSHb R1
+    MOV R1 0
+    PUSHb R1
+    MOV R1 0
+    PUSH R1
     LDRf R1 .floatLiteral_0
     PUSHf R1
+    MOV R1, R6-8
+    POPf R2
+    MOVf [R1] R2
     MVI R1 3
     PUSH R1
+    MOV R1, R6-12
+    POP R2
+    MOV [R1] R2
     MVIb R1 1
     PUSHb R1
+    MOV R1, R6-13
+    POPb R2
+    MOVb [R1] R2
     MVIb R1 1
     PUSHb R1
+    MOV R1, R6-14
+    POPb R2
+    MOVb [R1] R2
     MVI R1 0
     PUSH R1
+    MOV R1, R6-18
+    POP R2
+    MOV [R1] R2
     MVI R1 5
     PUSH R1
     MOV R1, R6-18

--- a/VM/tests/Compiler/CompileAndExecute/CompileAndExecute.tests.ts
+++ b/VM/tests/Compiler/CompileAndExecute/CompileAndExecute.tests.ts
@@ -436,7 +436,40 @@ func main() : int
 {
     return McCarthy(45);
 }
-`, 91]
+`, 91],
+[`
+func main() : int
+{            
+    let i : int = 1;
+    for let counter in 0 to 10
+    {
+        // variable declared and assigned inside a loop.
+        let r : int = counter * i; 
+        
+        i = i + r;
+    }
+
+    return i;
+}`, 39916800],
+[`
+func main() : int
+{            
+    let i : int = 1;
+
+    for let x in 0 to 10 // loop inclusive
+    {
+        let x1 = x * 2;
+        for let y in 0 to 10 // loop inclusive
+        {
+            // variable declared and assigned inside a loop.
+            let y1 : int = x1 * y; 
+        
+            i = i + y1;
+        }        
+    }
+
+    return i;
+}`, 6051]
     ].forEach((item) => {
         it(`should compile, assemble and execute to return the right value ` + item[0], () => {  
             const text = item[0] as string;

--- a/VM/tests/Compiler/Lexer.tests.ts
+++ b/VM/tests/Compiler/Lexer.tests.ts
@@ -328,7 +328,41 @@ describe("A Lexer object", () => {
         }
         return pairs;
     }
-    
+
+    [
+        [`a`],
+        [`aa`],
+        [`a_`],
+        [`_a`],
+        [`a_a`],
+        [`aLongIdentifier`],
+        [`a1`],
+        [`a11`],
+        [`a1a`]
+    ].forEach((item) => {
+        it(`should recognise identifier ${item[0].length}`, () => {  
+            let text = item[0] as string;
+            let source = new SourceText(text);
+            let lexer = new Lexer(source);
+            let tokens : Token[] = [];
+            
+            while(true)
+            {
+                let token = lexer.lex();
+                
+                if(token.kind == SyntaxType.Eof)
+                    break;
+            
+                tokens.push(token);
+            }
+
+            expect(tokens.length).toEqual(1);
+            tokens.forEach( (v, i) => {
+                expect(v.kind ).toEqual(SyntaxType.Identifier);
+            });
+        });
+    });
+
     [
         [`£`, [SyntaxType.BadToken] ],
         [`$`, [SyntaxType.BadToken] ],

--- a/VM/tests/Compiler/Lowering/Lowerer.tests.ts
+++ b/VM/tests/Compiler/Lowering/Lowerer.tests.ts
@@ -256,6 +256,8 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
+            AssignmentStatement
+                VariableExpression<n:int>
                 LiteralExpression<0:int>
             AssignmentStatement
                 VariableExpression<n:int>
@@ -313,8 +315,12 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<l3:leaf3>
-                LiteralExpression<null:leaf3>
             VariableDeclaration<l2:leaf2>
+            AssignmentStatement
+                VariableExpression<l3:leaf3>
+                LiteralExpression<null:leaf3>
+            AssignmentStatement
+                VariableExpression<l2:leaf2>
                 LiteralExpression<null:leaf2>
             AssignmentStatement
                 GetExpression<a1:int>
@@ -415,6 +421,8 @@ func main() : int {
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
+            AssignmentStatement
+                VariableExpression<n:int>
                 LiteralExpression<5:int>
             ReturnStatement
                 CallExpression<fib>
@@ -436,13 +444,19 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
-                LiteralExpression<0:int>
             VariableDeclaration<i:int>
+            VariableDeclaration<upperBound1:int>
+            AssignmentStatement
+                VariableExpression<n:int>
+                LiteralExpression<0:int>
+            AssignmentStatement
+                VariableExpression<i:int>
                 LiteralExpression<1:int>
             AssignmentStatement
                 VariableExpression<i:int>
                 LiteralExpression<1:int>
-            VariableDeclaration<upperBound1:int>
+            AssignmentStatement
+                VariableExpression<upperBound1:int>
                 LiteralExpression<100:int>
             GotoStatement<Label1>
             LabelStatement<Label2>
@@ -489,15 +503,23 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
+            VariableDeclaration<i:int>
+            VariableDeclaration<upperBound1:int>
+            VariableDeclaration<i:int>
+            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<n:int>
                 LiteralExpression<0:int>
             ConditionalGotoStatement<Label1:JIT=false>
                 LiteralExpression<true:bool>
-            VariableDeclaration<i:int>
+            AssignmentStatement
+                VariableExpression<i:int>
                 LiteralExpression<1:int>
             AssignmentStatement
                 VariableExpression<i:int>
                 LiteralExpression<1:int>
-            VariableDeclaration<upperBound1:int>
+            AssignmentStatement
+                VariableExpression<upperBound1:int>
                 LiteralExpression<100:int>
             GotoStatement<Label3>
             LabelStatement<Label4>
@@ -520,12 +542,14 @@ func main() : int
             LabelStatement<break1>
             GotoStatement<Label2>
             LabelStatement<Label1>
-            VariableDeclaration<i:int>
+            AssignmentStatement
+                VariableExpression<i:int>
                 LiteralExpression<100:int>
             AssignmentStatement
                 VariableExpression<i:int>
                 LiteralExpression<100:int>
-            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<upperBound2:int>
                 LiteralExpression<1000:int>
             GotoStatement<Label5>
             LabelStatement<Label6>
@@ -566,22 +590,32 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
-                LiteralExpression<0:int>
             VariableDeclaration<x:int>
+            VariableDeclaration<upperBound1:int>
+            VariableDeclaration<y:int>
+            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<n:int>
+                LiteralExpression<0:int>
+            AssignmentStatement
+                VariableExpression<x:int>
                 LiteralExpression<1:int>
             AssignmentStatement
                 VariableExpression<x:int>
                 LiteralExpression<1:int>
-            VariableDeclaration<upperBound1:int>
+            AssignmentStatement
+                VariableExpression<upperBound1:int>
                 LiteralExpression<100:int>
             GotoStatement<Label1>
             LabelStatement<Label2>
-            VariableDeclaration<y:int>
+            AssignmentStatement
+                VariableExpression<y:int>
                 LiteralExpression<100:int>
             AssignmentStatement
                 VariableExpression<y:int>
                 LiteralExpression<100:int>
-            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<upperBound2:int>
                 LiteralExpression<1000:int>
             GotoStatement<Label3>
             LabelStatement<Label4>
@@ -637,13 +671,21 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
-                LiteralExpression<0:int>
             VariableDeclaration<x:int>
+            VariableDeclaration<upperBound1:int>
+            VariableDeclaration<y:int>
+            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<n:int>
+                LiteralExpression<0:int>
+            AssignmentStatement
+                VariableExpression<x:int>
                 LiteralExpression<1:int>
             AssignmentStatement
                 VariableExpression<x:int>
                 LiteralExpression<1:int>
-            VariableDeclaration<upperBound1:int>
+            AssignmentStatement
+                VariableExpression<upperBound1:int>
                 LiteralExpression<100:int>
             GotoStatement<Label1>
             LabelStatement<Label2>
@@ -651,12 +693,14 @@ func main() : int
                 BinaryExpression<<>
                     VariableExpression<x:int>
                     LiteralExpression<50:int>
-            VariableDeclaration<y:int>
+            AssignmentStatement
+                VariableExpression<y:int>
                 LiteralExpression<100:int>
             AssignmentStatement
                 VariableExpression<y:int>
                 LiteralExpression<100:int>
-            VariableDeclaration<upperBound2:int>
+            AssignmentStatement
+                VariableExpression<upperBound2:int>
                 LiteralExpression<1000:int>
             GotoStatement<Label4>
             LabelStatement<Label5>
@@ -717,6 +761,8 @@ func main() : int
         ParameterDeclarationList
         BlockStatement
             VariableDeclaration<n:int>
+            AssignmentStatement
+                VariableExpression<n:int>
                 LiteralExpression<0:int>
             GotoStatement<continue1>
             LabelStatement<Label1>

--- a/VM/tests/Compiler/Parser.tests.ts
+++ b/VM/tests/Compiler/Parser.tests.ts
@@ -222,7 +222,30 @@ func b() : int
             ReturnStatementSyntax
                 IntegerLiteralExpressionSyntax<3>
 `],
-                
+[`func main() : int
+{
+    return 1;
+}
+
+func function_with_underscores_in_its_name() : int
+{
+    return 2;
+}
+`,
+`CompilationUnitSyntax
+    FunctionDeclarationStatementSyntax<main>
+        ParameterDeclarationListSyntax
+        TypeNameSyntax<int>
+        BlockStatementSyntax
+            ReturnStatementSyntax
+                IntegerLiteralExpressionSyntax<1>
+    FunctionDeclarationStatementSyntax<function_with_underscores_in_its_name>
+        ParameterDeclarationListSyntax
+        TypeNameSyntax<int>
+        BlockStatementSyntax
+            ReturnStatementSyntax
+                IntegerLiteralExpressionSyntax<2>
+`],                
 [`func add(a:int, b:int) : int => a + b;`, 
 `CompilationUnitSyntax
     LambdaDeclarationStatementSyntax<add>


### PR DESCRIPTION
- A more easily usable builtins system
- Underscores in identifiers
- Variable Declarations in loops had issues. Each execution of the loop would push new space on the stack for the variable and reinitialise it. Thus variables declared in loops did not work correctly. Now we use the lowerer to hoist the declarations of variables up to the top of the function. Initialisation is still done at the original declaration site.
- Further instances of automatic type conversion from int to float at call sites and return values 
- Unary minus operator for float